### PR TITLE
add modules and loose options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,33 @@
 /* global module */
-module.exports = {
-  plugins: [
-    require('babel-plugin-syntax-async-functions'),
-    require('babel-plugin-syntax-object-rest-spread'),
-    require('babel-plugin-syntax-trailing-function-commas'),
-    require('babel-plugin-transform-es2015-destructuring'),
-    require('babel-plugin-transform-es2015-modules-commonjs'),
-    require('babel-plugin-transform-es2015-parameters'),
-    require('babel-plugin-transform-es2015-sticky-regex'),
-    require('babel-plugin-transform-es2015-unicode-regex'),
-    require('babel-plugin-transform-strict-mode'),
-    require('babel-plugin-transform-object-rest-spread'),
-    require('babel-plugin-transform-async-to-generator'),
-  ],
-};
+
+module.exports = function(context, opts = {}) {
+  let loose = false;
+  let modules = true;
+
+  if (opts !== undefined) {
+    if (opts.loose !== undefined) loose = opts.loose;
+    if (opts.modules !== undefined) modules = opts.modules;
+  }
+
+  if (typeof loose !== 'boolean') throw new Error("Preset node5 'loose' option must be a boolean.");
+  if (typeof loose !== 'boolean') throw new Error("Preset node5 'modules' option must be a boolean.");
+
+  // be DRY
+  const optsLoose = { loose };
+
+  return {
+    plugins: [
+      require('babel-plugin-syntax-async-functions'),
+      require('babel-plugin-syntax-object-rest-spread'),
+      require('babel-plugin-syntax-trailing-function-commas'),
+      [require('babel-plugin-transform-es2015-destructuring'), optsLoose],
+      modules && [require('babel-plugin-transform-es2015-modules-commonjs'), optsLoose],
+      require('babel-plugin-transform-es2015-parameters'),
+      require('babel-plugin-transform-es2015-sticky-regex'),
+      require('babel-plugin-transform-es2015-unicode-regex'),
+      require('babel-plugin-transform-strict-mode'),
+      require('babel-plugin-transform-object-rest-spread'),
+      require('babel-plugin-transform-async-to-generator'),
+    ].filter(Boolean) // filter out falsy values
+  };
+}


### PR DESCRIPTION
Heavily inspired from https://github.com/babel/babel/blob/master/packages/babel-preset-es2015.

I tested by npm linking locally to one of my project and it works for me. You can do additional tests if you want.